### PR TITLE
Update: WineのVersionを10にする

### DIFF
--- a/fonts-ja.reg
+++ b/fonts-ja.reg
@@ -1,0 +1,28 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\FontSubstitutes]
+"MS UI Gothic"="Noto Sans CJK JP"
+"MS Gothic"="Noto Sans CJK JP"
+"MS PGothic"="Noto Sans CJK JP"
+"MS Mincho"="Noto Serif CJK JP"
+"MS PMincho"="Noto Serif CJK JP"
+"Meiryo"="Noto Sans CJK JP"
+"Meiryo UI"="Noto Sans CJK JP"
+
+
+[HKEY_CURRENT_USER\Control Panel\Desktop]
+"FontSmoothing"="2"
+"FontSmoothingType"=dword:00000002
+"FontSmoothingGamma"=dword:000005DC
+"FontSmoothingOrientation"=dword:00000001
+"LogPixels"=dword:00000078
+
+
+[HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink]
+"MS UI Gothic"=hex(7):4e,00,6f,00,74,00,6f,00,20,00,53,00,61,00,6e,00,73,00,20,00,43,00,4a,00,4b,00,20,00,4a,00,50,00,00,00,00,00
+"MS Gothic"=hex(7):4e,00,6f,00,74,00,6f,00,20,00,53,00,61,00,6e,00,73,00,20,00,43,00,4a,00,4b,00,20,00,4a,00,50,00,00,00,00,00
+"MS PGothic"=hex(7):4e,00,6f,00,74,00,6f,00,20,00,53,00,61,00,6e,00,73,00,20,00,43,00,4a,00,4b,00,20,00,4a,00,50,00,00,00,00,00
+"MS Mincho"=hex(7):4e,00,6f,00,74,00,6f,00,20,00,53,00,65,00,72,00,69,00,66,00,20,00,43,00,4a,00,4b,00,20,00,4a,00,50,00,00,00,00,00
+"MS PMincho"=hex(7):4e,00,6f,00,74,00,6f,00,20,00,53,00,65,00,72,00,69,00,66,00,20,00,43,00,4a,00,4b,00,20,00,4a,00,50,00,00,00,00,00
+"Meiryo"=hex(7):4e,00,6f,00,74,00,6f,00,20,00,53,00,61,00,6e,00,73,00,20,00,43,00,4a,00,4b,00,20,00,4a,00,50,00,00,00,00,00
+"Meiryo UI"=hex(7):4e,00,6f,00,74,00,6f,00,20,00,53,00,61,00,6e,00,73,00,20,00,43,00,4a,00,4b,00,20,00,4a,00,50,00,00,00,00,00

--- a/local-fonts.conf
+++ b/local-fonts.conf
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <!-- 日本語フォント優先 -->
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Noto Sans CJK JP</family>
+      <family>Noto Sans</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Noto Serif CJK JP</family>
+      <family>Noto Serif</family>
+    </prefer>
+  </alias>
+
+  <!-- Windows 日本語フォント名の別名 -->
+  <alias><family>MS Gothic</family><prefer><family>Noto Sans CJK JP</family></prefer></alias>
+  <alias><family>MS PGothic</family><prefer><family>Noto Sans CJK JP</family></prefer></alias>
+  <alias><family>MS UI Gothic</family><prefer><family>Noto Sans CJK JP</family></prefer></alias>
+  <alias><family>MS Mincho</family><prefer><family>Noto Serif CJK JP</family></prefer></alias>
+  <alias><family>MS PMincho</family><prefer><family>Noto Serif CJK JP</family></prefer></alias>
+  <alias><family>Meiryo</family><prefer><family>Noto Sans CJK JP</family></prefer></alias>
+  <alias><family>Meiryo UI</family><prefer><family>Noto Sans CJK JP</family></prefer></alias>
+
+  <!-- AA/ヒンティングの強制 -->
+  <match target="font">
+    <edit name="antialias" mode="assign"><bool>true</bool></edit>
+    <edit name="hinting" mode="assign"><bool>true</bool></edit>
+    <edit name="hintstyle" mode="assign"><const>hintslight</const></edit>
+    <edit name="rgba" mode="assign"><const>rgb</const></edit>
+    <edit name="lcdfilter" mode="assign"><const>lcddefault</const></edit>
+  </match>
+</fontconfig>


### PR DESCRIPTION
自分のために作成したのでPullRequestを送るか悩んだのですが、念の為送っておきます
録画ができることを確認していますが長期で安定して動作するかは不明です
WineのVersionを10.0.0.0にアップデートしました
フォントの問題が解決しております

<img width="1470" height="817" alt="image" src="https://github.com/user-attachments/assets/69a112e7-54e1-4bc8-9657-cc27439f9b1b" />



作成した経緯としては、録画後バッチ内で `AmatsukazeAddTask.exe` を動作させたかったのですが、`bcrypt.dll`が不足しているとのことで起動できませんでした
Wine10にアップデートすることで解決したのですが、`AmatsukazeAddTask` に指定したパスがWineのパスに勝手にマッピングされてしまい、うまく動作しませんでした(結局無駄な労力に)
ただ、goやrustなどの言語でコンパイルしたコードも`bcrypt.dll`が必要なためwine7上では動作せずwine10では安定動作したので一定の需要はあるかと思っています(外部のhttpサーバーにリクエストを送信してそこで`AmatsukazeAddTask.exe`を実行するアプローチを採用する予定)
フォント周りはclaudeにやらせました